### PR TITLE
Add hero party dataset

### DIFF
--- a/data/hero_parties.json
+++ b/data/hero_parties.json
@@ -1,0 +1,1522 @@
+[
+  {
+    "stage": 1,
+    "team": "1-1",
+    "members": [
+      {
+        "name": "セシルヤ",
+        "role": "勇者",
+        "hp": 140,
+        "attack": 39,
+        "mp": 54,
+        "defense": 24
+      },
+      {
+        "name": "セシルリス",
+        "role": "忍者",
+        "hp": 157,
+        "attack": 34,
+        "mp": 43,
+        "defense": 9
+      },
+      {
+        "name": "トールヤ",
+        "role": "戦士",
+        "hp": 157,
+        "attack": 34,
+        "mp": 47,
+        "defense": 18
+      },
+      {
+        "name": "トールド",
+        "role": "弓使い",
+        "hp": 144,
+        "attack": 28,
+        "mp": 34,
+        "defense": 10
+      }
+    ]
+  },
+  {
+    "stage": 1,
+    "team": "1-2",
+    "members": [
+      {
+        "name": "トールア",
+        "role": "勇者",
+        "hp": 134,
+        "attack": 26,
+        "mp": 31,
+        "defense": 18
+      },
+      {
+        "name": "ユリン",
+        "role": "弓使い",
+        "hp": 169,
+        "attack": 18,
+        "mp": 37,
+        "defense": 16
+      },
+      {
+        "name": "トールト",
+        "role": "戦士",
+        "hp": 132,
+        "attack": 28,
+        "mp": 36,
+        "defense": 17
+      },
+      {
+        "name": "ミナル",
+        "role": "魔法使い",
+        "hp": 111,
+        "attack": 18,
+        "mp": 34,
+        "defense": 17
+      }
+    ]
+  },
+  {
+    "stage": 1,
+    "team": "1-3",
+    "members": [
+      {
+        "name": "カイルス",
+        "role": "勇者",
+        "hp": 188,
+        "attack": 29,
+        "mp": 51,
+        "defense": 14
+      },
+      {
+        "name": "ミナゼ",
+        "role": "忍者",
+        "hp": 103,
+        "attack": 28,
+        "mp": 49,
+        "defense": 14
+      },
+      {
+        "name": "カイルト",
+        "role": "戦士",
+        "hp": 173,
+        "attack": 30,
+        "mp": 41,
+        "defense": 24
+      },
+      {
+        "name": "トールト",
+        "role": "弓使い",
+        "hp": 144,
+        "attack": 26,
+        "mp": 36,
+        "defense": 12
+      }
+    ]
+  },
+  {
+    "stage": 1,
+    "team": "1-4",
+    "members": [
+      {
+        "name": "バルドナ",
+        "role": "勇者",
+        "hp": 169,
+        "attack": 36,
+        "mp": 55,
+        "defense": 10
+      },
+      {
+        "name": "トールナ",
+        "role": "盗賊",
+        "hp": 96,
+        "attack": 29,
+        "mp": 45,
+        "defense": 20
+      },
+      {
+        "name": "カイルリス",
+        "role": "忍者",
+        "hp": 91,
+        "attack": 21,
+        "mp": 28,
+        "defense": 10
+      },
+      {
+        "name": "アイナド",
+        "role": "格闘家",
+        "hp": 104,
+        "attack": 39,
+        "mp": 36,
+        "defense": 11
+      }
+    ]
+  },
+  {
+    "stage": 1,
+    "team": "1-5",
+    "members": [
+      {
+        "name": "アイナア",
+        "role": "勇者",
+        "hp": 166,
+        "attack": 24,
+        "mp": 52,
+        "defense": 11
+      },
+      {
+        "name": "カイルト",
+        "role": "弓使い",
+        "hp": 161,
+        "attack": 28,
+        "mp": 28,
+        "defense": 11
+      },
+      {
+        "name": "アイナル",
+        "role": "僧侶",
+        "hp": 159,
+        "attack": 28,
+        "mp": 40,
+        "defense": 9
+      },
+      {
+        "name": "ユリヤ",
+        "role": "格闘家",
+        "hp": 108,
+        "attack": 25,
+        "mp": 47,
+        "defense": 24
+      }
+    ]
+  },
+  {
+    "stage": 1,
+    "team": "1-6",
+    "members": [
+      {
+        "name": "バルドゼ",
+        "role": "勇者",
+        "hp": 113,
+        "attack": 34,
+        "mp": 37,
+        "defense": 15
+      },
+      {
+        "name": "トールア",
+        "role": "盗賊",
+        "hp": 175,
+        "attack": 36,
+        "mp": 46,
+        "defense": 9
+      },
+      {
+        "name": "トールト",
+        "role": "戦士",
+        "hp": 185,
+        "attack": 40,
+        "mp": 62,
+        "defense": 15
+      },
+      {
+        "name": "バルドン",
+        "role": "弓使い",
+        "hp": 95,
+        "attack": 33,
+        "mp": 31,
+        "defense": 10
+      }
+    ]
+  },
+  {
+    "stage": 1,
+    "team": "1-7",
+    "members": [
+      {
+        "name": "トールン",
+        "role": "勇者",
+        "hp": 130,
+        "attack": 27,
+        "mp": 56,
+        "defense": 25
+      },
+      {
+        "name": "ジークリス",
+        "role": "格闘家",
+        "hp": 140,
+        "attack": 22,
+        "mp": 60,
+        "defense": 13
+      },
+      {
+        "name": "アレクト",
+        "role": "僧侶",
+        "hp": 94,
+        "attack": 27,
+        "mp": 47,
+        "defense": 11
+      },
+      {
+        "name": "ジークリス",
+        "role": "魔法使い",
+        "hp": 98,
+        "attack": 15,
+        "mp": 24,
+        "defense": 9
+      }
+    ]
+  },
+  {
+    "stage": 1,
+    "team": "1-8",
+    "members": [
+      {
+        "name": "ミナヤ",
+        "role": "勇者",
+        "hp": 172,
+        "attack": 28,
+        "mp": 44,
+        "defense": 10
+      },
+      {
+        "name": "ジークヤ",
+        "role": "弓使い",
+        "hp": 149,
+        "attack": 31,
+        "mp": 46,
+        "defense": 13
+      },
+      {
+        "name": "アレクド",
+        "role": "魔法使い",
+        "hp": 118,
+        "attack": 17,
+        "mp": 25,
+        "defense": 8
+      },
+      {
+        "name": "ミナゼ",
+        "role": "忍者",
+        "hp": 117,
+        "attack": 22,
+        "mp": 32,
+        "defense": 10
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-1",
+    "members": [
+      {
+        "name": "ミナリス",
+        "role": "勇者",
+        "hp": 139,
+        "attack": 46,
+        "mp": 70,
+        "defense": 19
+      },
+      {
+        "name": "ユリア",
+        "role": "盗賊",
+        "hp": 148,
+        "attack": 33,
+        "mp": 52,
+        "defense": 24
+      },
+      {
+        "name": "ジークナ",
+        "role": "戦士",
+        "hp": 193,
+        "attack": 34,
+        "mp": 70,
+        "defense": 28
+      },
+      {
+        "name": "トールリス",
+        "role": "僧侶",
+        "hp": 104,
+        "attack": 35,
+        "mp": 38,
+        "defense": 17
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-2",
+    "members": [
+      {
+        "name": "ユリナ",
+        "role": "勇者",
+        "hp": 133,
+        "attack": 33,
+        "mp": 58,
+        "defense": 26
+      },
+      {
+        "name": "アレクス",
+        "role": "格闘家",
+        "hp": 167,
+        "attack": 45,
+        "mp": 45,
+        "defense": 16
+      },
+      {
+        "name": "ユリド",
+        "role": "忍者",
+        "hp": 170,
+        "attack": 39,
+        "mp": 36,
+        "defense": 25
+      },
+      {
+        "name": "カイルリス",
+        "role": "魔法使い",
+        "hp": 133,
+        "attack": 23,
+        "mp": 40,
+        "defense": 9
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-3",
+    "members": [
+      {
+        "name": "トールア",
+        "role": "勇者",
+        "hp": 237,
+        "attack": 49,
+        "mp": 53,
+        "defense": 14
+      },
+      {
+        "name": "ユリン",
+        "role": "魔法使い",
+        "hp": 94,
+        "attack": 19,
+        "mp": 50,
+        "defense": 19
+      },
+      {
+        "name": "ユリス",
+        "role": "格闘家",
+        "hp": 210,
+        "attack": 28,
+        "mp": 46,
+        "defense": 16
+      },
+      {
+        "name": "バルドス",
+        "role": "弓使い",
+        "hp": 190,
+        "attack": 28,
+        "mp": 34,
+        "defense": 12
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-4",
+    "members": [
+      {
+        "name": "トールナ",
+        "role": "勇者",
+        "hp": 182,
+        "attack": 33,
+        "mp": 61,
+        "defense": 20
+      },
+      {
+        "name": "バルドゼ",
+        "role": "弓使い",
+        "hp": 198,
+        "attack": 34,
+        "mp": 62,
+        "defense": 17
+      },
+      {
+        "name": "カイルゼ",
+        "role": "忍者",
+        "hp": 160,
+        "attack": 42,
+        "mp": 42,
+        "defense": 17
+      },
+      {
+        "name": "セシルト",
+        "role": "戦士",
+        "hp": 154,
+        "attack": 34,
+        "mp": 64,
+        "defense": 22
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-5",
+    "members": [
+      {
+        "name": "リリィナ",
+        "role": "勇者",
+        "hp": 249,
+        "attack": 28,
+        "mp": 75,
+        "defense": 22
+      },
+      {
+        "name": "バルドゼ",
+        "role": "忍者",
+        "hp": 230,
+        "attack": 33,
+        "mp": 37,
+        "defense": 28
+      },
+      {
+        "name": "セシルン",
+        "role": "戦士",
+        "hp": 207,
+        "attack": 44,
+        "mp": 75,
+        "defense": 24
+      },
+      {
+        "name": "トールア",
+        "role": "僧侶",
+        "hp": 126,
+        "attack": 38,
+        "mp": 39,
+        "defense": 20
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-6",
+    "members": [
+      {
+        "name": "ミナト",
+        "role": "勇者",
+        "hp": 137,
+        "attack": 35,
+        "mp": 78,
+        "defense": 28
+      },
+      {
+        "name": "アイナリス",
+        "role": "盗賊",
+        "hp": 157,
+        "attack": 36,
+        "mp": 46,
+        "defense": 29
+      },
+      {
+        "name": "ミナス",
+        "role": "忍者",
+        "hp": 169,
+        "attack": 40,
+        "mp": 47,
+        "defense": 25
+      },
+      {
+        "name": "カイルア",
+        "role": "戦士",
+        "hp": 205,
+        "attack": 35,
+        "mp": 64,
+        "defense": 22
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-7",
+    "members": [
+      {
+        "name": "ジークヤ",
+        "role": "勇者",
+        "hp": 214,
+        "attack": 28,
+        "mp": 53,
+        "defense": 26
+      },
+      {
+        "name": "トールア",
+        "role": "忍者",
+        "hp": 161,
+        "attack": 36,
+        "mp": 51,
+        "defense": 29
+      },
+      {
+        "name": "ミナリス",
+        "role": "魔法使い",
+        "hp": 106,
+        "attack": 20,
+        "mp": 44,
+        "defense": 9
+      },
+      {
+        "name": "セシルヤ",
+        "role": "格闘家",
+        "hp": 161,
+        "attack": 26,
+        "mp": 71,
+        "defense": 26
+      }
+    ]
+  },
+  {
+    "stage": 2,
+    "team": "2-8",
+    "members": [
+      {
+        "name": "カイルリス",
+        "role": "勇者",
+        "hp": 250,
+        "attack": 48,
+        "mp": 39,
+        "defense": 15
+      },
+      {
+        "name": "リリィン",
+        "role": "戦士",
+        "hp": 198,
+        "attack": 55,
+        "mp": 72,
+        "defense": 24
+      },
+      {
+        "name": "リリィヤ",
+        "role": "僧侶",
+        "hp": 133,
+        "attack": 41,
+        "mp": 55,
+        "defense": 20
+      },
+      {
+        "name": "ジークア",
+        "role": "弓使い",
+        "hp": 208,
+        "attack": 33,
+        "mp": 33,
+        "defense": 25
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-1",
+    "members": [
+      {
+        "name": "ジークナ",
+        "role": "勇者",
+        "hp": 305,
+        "attack": 36,
+        "mp": 62,
+        "defense": 16
+      },
+      {
+        "name": "バルドア",
+        "role": "格闘家",
+        "hp": 267,
+        "attack": 40,
+        "mp": 76,
+        "defense": 22
+      },
+      {
+        "name": "ユリド",
+        "role": "盗賊",
+        "hp": 144,
+        "attack": 54,
+        "mp": 83,
+        "defense": 34
+      },
+      {
+        "name": "アレクト",
+        "role": "忍者",
+        "hp": 254,
+        "attack": 36,
+        "mp": 72,
+        "defense": 14
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-2",
+    "members": [
+      {
+        "name": "ミナゼ",
+        "role": "勇者",
+        "hp": 161,
+        "attack": 48,
+        "mp": 54,
+        "defense": 35
+      },
+      {
+        "name": "バルドヤ",
+        "role": "魔法使い",
+        "hp": 201,
+        "attack": 44,
+        "mp": 59,
+        "defense": 24
+      },
+      {
+        "name": "セシルリス",
+        "role": "盗賊",
+        "hp": 174,
+        "attack": 31,
+        "mp": 56,
+        "defense": 17
+      },
+      {
+        "name": "ユリン",
+        "role": "弓使い",
+        "hp": 244,
+        "attack": 32,
+        "mp": 69,
+        "defense": 28
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-3",
+    "members": [
+      {
+        "name": "アレクヤ",
+        "role": "勇者",
+        "hp": 169,
+        "attack": 56,
+        "mp": 73,
+        "defense": 32
+      },
+      {
+        "name": "バルドヤ",
+        "role": "格闘家",
+        "hp": 184,
+        "attack": 46,
+        "mp": 83,
+        "defense": 27
+      },
+      {
+        "name": "ミナゼ",
+        "role": "魔法使い",
+        "hp": 176,
+        "attack": 33,
+        "mp": 48,
+        "defense": 28
+      },
+      {
+        "name": "アレクト",
+        "role": "戦士",
+        "hp": 329,
+        "attack": 36,
+        "mp": 73,
+        "defense": 31
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-4",
+    "members": [
+      {
+        "name": "トールル",
+        "role": "勇者",
+        "hp": 243,
+        "attack": 56,
+        "mp": 56,
+        "defense": 19
+      },
+      {
+        "name": "バルドゼ",
+        "role": "弓使い",
+        "hp": 174,
+        "attack": 28,
+        "mp": 57,
+        "defense": 31
+      },
+      {
+        "name": "リリィナ",
+        "role": "格闘家",
+        "hp": 212,
+        "attack": 36,
+        "mp": 48,
+        "defense": 33
+      },
+      {
+        "name": "カイルン",
+        "role": "戦士",
+        "hp": 242,
+        "attack": 49,
+        "mp": 93,
+        "defense": 26
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-5",
+    "members": [
+      {
+        "name": "リリィル",
+        "role": "勇者",
+        "hp": 280,
+        "attack": 48,
+        "mp": 52,
+        "defense": 27
+      },
+      {
+        "name": "ユリン",
+        "role": "弓使い",
+        "hp": 206,
+        "attack": 42,
+        "mp": 76,
+        "defense": 23
+      },
+      {
+        "name": "セシルア",
+        "role": "戦士",
+        "hp": 190,
+        "attack": 66,
+        "mp": 66,
+        "defense": 28
+      },
+      {
+        "name": "ミナド",
+        "role": "魔法使い",
+        "hp": 199,
+        "attack": 40,
+        "mp": 38,
+        "defense": 25
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-6",
+    "members": [
+      {
+        "name": "アイナド",
+        "role": "勇者",
+        "hp": 235,
+        "attack": 48,
+        "mp": 48,
+        "defense": 36
+      },
+      {
+        "name": "ジークル",
+        "role": "格闘家",
+        "hp": 163,
+        "attack": 49,
+        "mp": 78,
+        "defense": 24
+      },
+      {
+        "name": "バルドン",
+        "role": "盗賊",
+        "hp": 151,
+        "attack": 48,
+        "mp": 43,
+        "defense": 28
+      },
+      {
+        "name": "カイルリス",
+        "role": "僧侶",
+        "hp": 235,
+        "attack": 32,
+        "mp": 57,
+        "defense": 23
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-7",
+    "members": [
+      {
+        "name": "ジークリス",
+        "role": "勇者",
+        "hp": 206,
+        "attack": 33,
+        "mp": 56,
+        "defense": 17
+      },
+      {
+        "name": "カイルル",
+        "role": "盗賊",
+        "hp": 256,
+        "attack": 50,
+        "mp": 76,
+        "defense": 23
+      },
+      {
+        "name": "リリィル",
+        "role": "格闘家",
+        "hp": 188,
+        "attack": 51,
+        "mp": 88,
+        "defense": 17
+      },
+      {
+        "name": "カイルス",
+        "role": "僧侶",
+        "hp": 177,
+        "attack": 35,
+        "mp": 52,
+        "defense": 24
+      }
+    ]
+  },
+  {
+    "stage": 3,
+    "team": "3-8",
+    "members": [
+      {
+        "name": "トールド",
+        "role": "勇者",
+        "hp": 243,
+        "attack": 48,
+        "mp": 68,
+        "defense": 38
+      },
+      {
+        "name": "アイナド",
+        "role": "格闘家",
+        "hp": 230,
+        "attack": 48,
+        "mp": 84,
+        "defense": 20
+      },
+      {
+        "name": "リリィゼ",
+        "role": "忍者",
+        "hp": 145,
+        "attack": 37,
+        "mp": 69,
+        "defense": 24
+      },
+      {
+        "name": "バルドト",
+        "role": "盗賊",
+        "hp": 253,
+        "attack": 33,
+        "mp": 48,
+        "defense": 30
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-1",
+    "members": [
+      {
+        "name": "リリィゼ",
+        "role": "勇者",
+        "hp": 282,
+        "attack": 46,
+        "mp": 96,
+        "defense": 46
+      },
+      {
+        "name": "ミナナ",
+        "role": "格闘家",
+        "hp": 334,
+        "attack": 68,
+        "mp": 90,
+        "defense": 30
+      },
+      {
+        "name": "アイナゼ",
+        "role": "盗賊",
+        "hp": 277,
+        "attack": 52,
+        "mp": 84,
+        "defense": 19
+      },
+      {
+        "name": "アイナル",
+        "role": "戦士",
+        "hp": 409,
+        "attack": 63,
+        "mp": 96,
+        "defense": 46
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-2",
+    "members": [
+      {
+        "name": "ユリス",
+        "role": "勇者",
+        "hp": 380,
+        "attack": 80,
+        "mp": 120,
+        "defense": 48
+      },
+      {
+        "name": "カイルリス",
+        "role": "格闘家",
+        "hp": 294,
+        "attack": 44,
+        "mp": 62,
+        "defense": 26
+      },
+      {
+        "name": "リリィナ",
+        "role": "僧侶",
+        "hp": 272,
+        "attack": 59,
+        "mp": 54,
+        "defense": 28
+      },
+      {
+        "name": "ミナゼ",
+        "role": "魔法使い",
+        "hp": 225,
+        "attack": 44,
+        "mp": 53,
+        "defense": 35
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-3",
+    "members": [
+      {
+        "name": "バルドル",
+        "role": "勇者",
+        "hp": 378,
+        "attack": 62,
+        "mp": 116,
+        "defense": 32
+      },
+      {
+        "name": "セシルナ",
+        "role": "格闘家",
+        "hp": 264,
+        "attack": 46,
+        "mp": 112,
+        "defense": 46
+      },
+      {
+        "name": "カイルゼ",
+        "role": "盗賊",
+        "hp": 302,
+        "attack": 37,
+        "mp": 77,
+        "defense": 18
+      },
+      {
+        "name": "リリィン",
+        "role": "僧侶",
+        "hp": 320,
+        "attack": 33,
+        "mp": 89,
+        "defense": 20
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-4",
+    "members": [
+      {
+        "name": "ユリト",
+        "role": "勇者",
+        "hp": 260,
+        "attack": 54,
+        "mp": 114,
+        "defense": 30
+      },
+      {
+        "name": "セシルヤ",
+        "role": "格闘家",
+        "hp": 260,
+        "attack": 54,
+        "mp": 108,
+        "defense": 50
+      },
+      {
+        "name": "ジークゼ",
+        "role": "弓使い",
+        "hp": 329,
+        "attack": 49,
+        "mp": 54,
+        "defense": 35
+      },
+      {
+        "name": "アイナゼ",
+        "role": "盗賊",
+        "hp": 248,
+        "attack": 37,
+        "mp": 75,
+        "defense": 37
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-5",
+    "members": [
+      {
+        "name": "アレクド",
+        "role": "勇者",
+        "hp": 370,
+        "attack": 42,
+        "mp": 98,
+        "defense": 40
+      },
+      {
+        "name": "トールア",
+        "role": "弓使い",
+        "hp": 219,
+        "attack": 40,
+        "mp": 54,
+        "defense": 18
+      },
+      {
+        "name": "セシルド",
+        "role": "僧侶",
+        "hp": 166,
+        "attack": 48,
+        "mp": 59,
+        "defense": 27
+      },
+      {
+        "name": "トールゼ",
+        "role": "盗賊",
+        "hp": 336,
+        "attack": 66,
+        "mp": 108,
+        "defense": 28
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-6",
+    "members": [
+      {
+        "name": "アイナア",
+        "role": "勇者",
+        "hp": 228,
+        "attack": 78,
+        "mp": 94,
+        "defense": 20
+      },
+      {
+        "name": "ミナア",
+        "role": "盗賊",
+        "hp": 275,
+        "attack": 48,
+        "mp": 64,
+        "defense": 25
+      },
+      {
+        "name": "アイナヤ",
+        "role": "格闘家",
+        "hp": 202,
+        "attack": 46,
+        "mp": 68,
+        "defense": 46
+      },
+      {
+        "name": "セシルリス",
+        "role": "弓使い",
+        "hp": 326,
+        "attack": 51,
+        "mp": 88,
+        "defense": 40
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-7",
+    "members": [
+      {
+        "name": "アレクリス",
+        "role": "勇者",
+        "hp": 380,
+        "attack": 68,
+        "mp": 62,
+        "defense": 34
+      },
+      {
+        "name": "アイナト",
+        "role": "僧侶",
+        "hp": 273,
+        "attack": 56,
+        "mp": 86,
+        "defense": 33
+      },
+      {
+        "name": "リリィヤ",
+        "role": "魔法使い",
+        "hp": 225,
+        "attack": 50,
+        "mp": 62,
+        "defense": 32
+      },
+      {
+        "name": "ユリナ",
+        "role": "忍者",
+        "hp": 226,
+        "attack": 64,
+        "mp": 75,
+        "defense": 41
+      }
+    ]
+  },
+  {
+    "stage": 4,
+    "team": "4-8",
+    "members": [
+      {
+        "name": "ジークリス",
+        "role": "勇者",
+        "hp": 286,
+        "attack": 80,
+        "mp": 114,
+        "defense": 34
+      },
+      {
+        "name": "ミナド",
+        "role": "魔法使い",
+        "hp": 233,
+        "attack": 49,
+        "mp": 49,
+        "defense": 35
+      },
+      {
+        "name": "トールゼ",
+        "role": "戦士",
+        "hp": 422,
+        "attack": 72,
+        "mp": 123,
+        "defense": 50
+      },
+      {
+        "name": "バルドス",
+        "role": "格闘家",
+        "hp": 380,
+        "attack": 80,
+        "mp": 66,
+        "defense": 34
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-1",
+    "members": [
+      {
+        "name": "ジークス",
+        "role": "勇者",
+        "hp": 297,
+        "attack": 85,
+        "mp": 145,
+        "defense": 32
+      },
+      {
+        "name": "ジークゼ",
+        "role": "魔法使い",
+        "hp": 204,
+        "attack": 57,
+        "mp": 52,
+        "defense": 35
+      },
+      {
+        "name": "ミナル",
+        "role": "弓使い",
+        "hp": 365,
+        "attack": 82,
+        "mp": 116,
+        "defense": 25
+      },
+      {
+        "name": "リリィン",
+        "role": "僧侶",
+        "hp": 338,
+        "attack": 62,
+        "mp": 112,
+        "defense": 50
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-2",
+    "members": [
+      {
+        "name": "トールル",
+        "role": "勇者",
+        "hp": 500,
+        "attack": 82,
+        "mp": 130,
+        "defense": 40
+      },
+      {
+        "name": "ユリリス",
+        "role": "戦士",
+        "hp": 393,
+        "attack": 90,
+        "mp": 143,
+        "defense": 66
+      },
+      {
+        "name": "リリィン",
+        "role": "僧侶",
+        "hp": 338,
+        "attack": 74,
+        "mp": 68,
+        "defense": 48
+      },
+      {
+        "name": "ミナヤ",
+        "role": "忍者",
+        "hp": 270,
+        "attack": 45,
+        "mp": 74,
+        "defense": 51
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-3",
+    "members": [
+      {
+        "name": "ユリス",
+        "role": "勇者",
+        "hp": 280,
+        "attack": 82,
+        "mp": 87,
+        "defense": 32
+      },
+      {
+        "name": "トールヤ",
+        "role": "僧侶",
+        "hp": 352,
+        "attack": 68,
+        "mp": 116,
+        "defense": 28
+      },
+      {
+        "name": "リリィナ",
+        "role": "魔法使い",
+        "hp": 232,
+        "attack": 50,
+        "mp": 54,
+        "defense": 31
+      },
+      {
+        "name": "ユリヤ",
+        "role": "忍者",
+        "hp": 247,
+        "attack": 58,
+        "mp": 83,
+        "defense": 22
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-4",
+    "members": [
+      {
+        "name": "トールド",
+        "role": "勇者",
+        "hp": 350,
+        "attack": 70,
+        "mp": 132,
+        "defense": 47
+      },
+      {
+        "name": "トールル",
+        "role": "盗賊",
+        "hp": 362,
+        "attack": 83,
+        "mp": 130,
+        "defense": 51
+      },
+      {
+        "name": "ユリゼ",
+        "role": "格闘家",
+        "hp": 280,
+        "attack": 52,
+        "mp": 112,
+        "defense": 60
+      },
+      {
+        "name": "バルドト",
+        "role": "魔法使い",
+        "hp": 197,
+        "attack": 68,
+        "mp": 77,
+        "defense": 26
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-5",
+    "members": [
+      {
+        "name": "リリィア",
+        "role": "勇者",
+        "hp": 300,
+        "attack": 60,
+        "mp": 85,
+        "defense": 40
+      },
+      {
+        "name": "リリィゼ",
+        "role": "魔法使い",
+        "hp": 257,
+        "attack": 38,
+        "mp": 64,
+        "defense": 35
+      },
+      {
+        "name": "ユリド",
+        "role": "格闘家",
+        "hp": 407,
+        "attack": 100,
+        "mp": 142,
+        "defense": 35
+      },
+      {
+        "name": "リリィス",
+        "role": "盗賊",
+        "hp": 371,
+        "attack": 76,
+        "mp": 81,
+        "defense": 51
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-6",
+    "members": [
+      {
+        "name": "トールリス",
+        "role": "勇者",
+        "hp": 362,
+        "attack": 65,
+        "mp": 125,
+        "defense": 30
+      },
+      {
+        "name": "アイナゼ",
+        "role": "僧侶",
+        "hp": 288,
+        "attack": 74,
+        "mp": 94,
+        "defense": 42
+      },
+      {
+        "name": "トールゼ",
+        "role": "魔法使い",
+        "hp": 187,
+        "attack": 49,
+        "mp": 98,
+        "defense": 40
+      },
+      {
+        "name": "カイルス",
+        "role": "格闘家",
+        "hp": 282,
+        "attack": 92,
+        "mp": 100,
+        "defense": 37
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-7",
+    "members": [
+      {
+        "name": "ジークア",
+        "role": "勇者",
+        "hp": 345,
+        "attack": 85,
+        "mp": 115,
+        "defense": 27
+      },
+      {
+        "name": "セシルア",
+        "role": "盗賊",
+        "hp": 348,
+        "attack": 87,
+        "mp": 72,
+        "defense": 29
+      },
+      {
+        "name": "アイナル",
+        "role": "格闘家",
+        "hp": 475,
+        "attack": 62,
+        "mp": 87,
+        "defense": 62
+      },
+      {
+        "name": "アレクン",
+        "role": "忍者",
+        "hp": 445,
+        "attack": 67,
+        "mp": 87,
+        "defense": 51
+      }
+    ]
+  },
+  {
+    "stage": 5,
+    "team": "5-8",
+    "members": [
+      {
+        "name": "セシルト",
+        "role": "勇者",
+        "hp": 367,
+        "attack": 90,
+        "mp": 135,
+        "defense": 45
+      },
+      {
+        "name": "リリィド",
+        "role": "戦士",
+        "hp": 283,
+        "attack": 107,
+        "mp": 145,
+        "defense": 38
+      },
+      {
+        "name": "ユリア",
+        "role": "忍者",
+        "hp": 274,
+        "attack": 87,
+        "mp": 90,
+        "defense": 36
+      },
+      {
+        "name": "セシルス",
+        "role": "魔法使い",
+        "hp": 323,
+        "attack": 50,
+        "mp": 87,
+        "defense": 40
+      }
+    ]
+  }
+]

--- a/scenes/hero_invade.html
+++ b/scenes/hero_invade.html
@@ -17,6 +17,7 @@
     import { TurnManager } from '../scripts/turn_manager.js';
     import config from '../data/game_config.json' assert { type: 'json' };
     import mapInfo from '../data/map.json' assert { type: 'json' };
+    import heroParties from '../data/hero_parties.json' assert { type: 'json' };
 
     const map = generateMap(config.gridWidth, config.gridHeight, mapInfo.defaultTile);
     const renderer = new MapRenderer(document.getElementById('mapCanvas'), map);
@@ -37,6 +38,7 @@
     }
 
     document.getElementById('nextTurn').addEventListener('click', nextTurn);
+    console.log('Loaded hero parties', heroParties);
     renderer.render();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add structured hero party data for multiple waves
- import hero party data in the hero invasion test scene

## Testing
- `jq length data/hero_parties.json`

------
https://chatgpt.com/codex/tasks/task_e_6852f2912e34832eb2e4e76aeac8ed88