### PR TITLE
Add layered map rendering demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 │   ├── hero_parties.json        ← 勇者パーティ編成
 │   ├── heroes.json              ← 職業定義・セリフ構成
 │   ├── map.json                 ← 地形・資源構成
+│   ├── layered_map.json         ← レイヤー付きマップサンプル
 │   ├── monsters.json            ← 魔物ID・種族構成
 │   └── monsters_detailed.json   ← 魔物詳細パラメータ
 │
@@ -21,6 +22,7 @@
 │   ├── game.html                ← メインUI
 │   ├── hero_invade.html         ← 勇者侵攻モードUI
 │   ├── monster_canvas.html      ← 魔物配置モードUI
+│   ├── layered_map.html         ← レイヤー構造マップ表示
 │   └── index.html               ← ランチャー画面
 │
 ├── scripts/                 # ゲーム制御スクリプト
@@ -28,6 +30,7 @@
 │   ├── turn_manager.js          ← フェーズ・wave制御
 │   ├── hero_ai.js               ← 勇者探索AI
 │   ├── map_renderer.js          ← マップ描画
+│   ├── layered_map_renderer.js  ← レイヤーマップ描画
 │   └── monster_canvas.js        ← 魔物配置処理
 │
 ├── styles/                 # 共通スタイル
@@ -52,6 +55,8 @@
 ## 実行方法
 
 ブラウザで`scenes/index.html`を開くとランチャー画面が表示されます。開発中のため、ローカルの簡易HTTPサーバなどで公開すると動作確認しやすくなります。
+
+`scenes/layered_map.html`を開くと、レイヤー構造を用いたマップ描画サンプルを確認できます。
 
 ## 今後の追加予定
 

--- a/data/layered_map.json
+++ b/data/layered_map.json
@@ -1,0 +1,29 @@
+{
+  "size": [40, 20],
+  "layers": [
+    {
+      "name": "background",
+      "tiles": [
+        {"type": "grass", "area": [[0,0], [39,19]]},
+        {"type": "building", "position": [18,0], "size": [4,4]}
+      ]
+    },
+    {
+      "name": "terrain",
+      "tiles": [
+        {"type": "soil", "area": [[0,15],[39,19]]},
+        {"type": "rock", "line": [[0,14],[39,14]]}
+      ]
+    },
+    {
+      "name": "object",
+      "objects": [
+        {"type": "slime", "position": [5,16]},
+        {"type": "hero_corpse", "position": [14,15]}
+      ]
+    }
+  ],
+  "ui": [
+    {"type": "label", "content": "STAGE CLEAR", "position": [20,1]}
+  ]
+}

--- a/scenes/index.html
+++ b/scenes/index.html
@@ -9,6 +9,7 @@
   <ul>
     <li><a href="monster_canvas.html">🧪 モンスターラボを開く</a></li>
     <li><a href="game.html">🎮 勇者ゲームをプレイ</a></li>
+    <li><a href="layered_map.html">🗺️ レイヤーマップ表示</a></li>
   </ul>
 </body>
 </html>

--- a/scenes/layered_map.html
+++ b/scenes/layered_map.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>Layered Map Demo</title>
+  <link rel="stylesheet" href="../styles/styles.css" />
+</head>
+<body>
+  <h1>Layered Map Demo</h1>
+  <canvas id="layeredCanvas"></canvas>
+  <script type="module">
+    import mapData from '../data/layered_map.json' assert { type: 'json' };
+    import { LayeredMapRenderer } from '../scripts/layered_map_renderer.js';
+
+    const canvas = document.getElementById('layeredCanvas');
+    const renderer = new LayeredMapRenderer(canvas, mapData);
+    renderer.render();
+  </script>
+</body>
+</html>

--- a/scripts/layered_map_renderer.js
+++ b/scripts/layered_map_renderer.js
@@ -1,0 +1,94 @@
+export class LayeredMapRenderer {
+  constructor(canvas, mapData) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.mapData = mapData;
+    this.cellSize = 16;
+    canvas.width = mapData.size[0] * this.cellSize;
+    canvas.height = mapData.size[1] * this.cellSize;
+  }
+
+  render() {
+    for (const layer of this.mapData.layers) {
+      if (layer.tiles) {
+        for (const tile of layer.tiles) {
+          this.#drawTiles(tile);
+        }
+      }
+      if (layer.objects) {
+        for (const obj of layer.objects) {
+          this.#drawObject(obj);
+        }
+      }
+    }
+
+    if (this.mapData.ui) {
+      this.ctx.fillStyle = 'black';
+      this.ctx.font = 'bold 16px sans-serif';
+      for (const ui of this.mapData.ui) {
+        if (ui.type === 'label') {
+          const [x, y] = ui.position;
+          this.ctx.fillText(ui.content, x * this.cellSize, (y + 1) * this.cellSize);
+        }
+      }
+    }
+  }
+
+  #drawTiles(tile) {
+    if (tile.area) {
+      const [[sx, sy], [ex, ey]] = tile.area;
+      for (let y = sy; y <= ey; y++) {
+        for (let x = sx; x <= ex; x++) {
+          this.#fillTile(tile.type, x, y);
+        }
+      }
+    } else if (tile.position) {
+      const [x0, y0] = tile.position;
+      const [w, h] = tile.size || [1, 1];
+      for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+          this.#fillTile(tile.type, x0 + x, y0 + y);
+        }
+      }
+    } else if (tile.line) {
+      const [[sx, sy], [ex, ey]] = tile.line;
+      const dx = Math.sign(ex - sx);
+      const dy = Math.sign(ey - sy);
+      const len = Math.max(Math.abs(ex - sx), Math.abs(ey - sy));
+      for (let i = 0; i <= len; i++) {
+        this.#fillTile(tile.type, sx + dx * i, sy + dy * i);
+      }
+    }
+  }
+
+  #fillTile(type, x, y) {
+    const colors = {
+      grass: '#77aa77',
+      soil: '#aa8855',
+      rock: '#888888',
+      building: '#5555aa'
+    };
+    this.ctx.fillStyle = colors[type] || '#000000';
+    this.ctx.fillRect(
+      x * this.cellSize,
+      y * this.cellSize,
+      this.cellSize,
+      this.cellSize
+    );
+  }
+
+  #drawObject(obj) {
+    const colors = {
+      slime: '#00cc88',
+      hero_corpse: '#884488'
+    };
+    const [x, y] = obj.position;
+    this.ctx.fillStyle = colors[obj.type] || '#000';
+    this.ctx.fillRect(
+      x * this.cellSize + 2,
+      y * this.cellSize + 2,
+      this.cellSize - 4,
+      this.cellSize - 4
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `layered_map.json` with YAML-described layout
- implement `LayeredMapRenderer` for drawing layered maps
- provide `layered_map.html` demo and link from index
- document new files and usage in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685340cb4aac832e99c932806f5bca6a