### PR TITLE
Introduce diggable paths

### DIFF
--- a/data/layered_map.json
+++ b/data/layered_map.json
@@ -12,7 +12,9 @@
       "name": "terrain",
       "tiles": [
         {"type": "soil", "area": [[0,15],[39,19]]},
-        {"type": "rock", "line": [[0,14],[39,14]]}
+        {"type": "rock", "line": [[0,14],[39,14]]},
+        {"type": "path", "line": [[18,4],[22,4]]},
+        {"type": "path", "line": [[20,4],[20,19]]}
       ]
     },
     {

--- a/lib/resourceManager.js
+++ b/lib/resourceManager.js
@@ -6,7 +6,8 @@ export function generateMap(width, height, defaultTile) {
       row.push({
         nutrients: defaultTile.nutrients,
         mana: defaultTile.mana,
-        monster: null
+        monster: null,
+        type: 'soil'
       });
     }
     tiles.push(row);

--- a/scenes/hero_invade.html
+++ b/scenes/hero_invade.html
@@ -33,6 +33,12 @@
       config.gridHeight,
       mapInfo.defaultTile
     );
+    for (let x = 0; x <= 20; x++) {
+      map.tiles[0][x].type = 'path';
+    }
+    for (let y = 0; y <= 20; y++) {
+      map.tiles[y][20].type = 'path';
+    }
     const renderer = new MapRenderer(document.getElementById('mapCanvas'), map);
     const tm = new TurnManager(config.stageCount, config.wavesPerStage);
 
@@ -90,6 +96,13 @@
     document.getElementById('nextTurn').addEventListener('click', nextTurn);
     renderer.render();
     updateStatus();
+
+    window.dig = (x, y) => {
+      if (map.tiles[y] && map.tiles[y][x]) {
+        map.tiles[y][x].type = 'path';
+        renderer.render(heroes);
+      }
+    };
   </script>
 </body>
 </html>

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -53,10 +53,18 @@ function createMap() {
         nutrients: b.nutrients,
         mana: b.mana,
         monster: null,
-        fire: 0
+        fire: 0,
+        type: 'soil'
       });
     }
     map.push(row);
+  }
+
+  for (let x = 0; x <= demonLord.x; x++) {
+    map[0][x].type = 'path';
+  }
+  for (let y = 0; y <= demonLord.y; y++) {
+    map[y][demonLord.x].type = 'path';
   }
 }
 
@@ -96,7 +104,14 @@ function heroMove() {
   ].filter(d => {
     const nx = hero.x + d[0];
     const ny = hero.y + d[1];
-    return nx >= 0 && ny >= 0 && nx < gridSize && ny < gridSize && !visited.has(`${nx},${ny}`);
+    return (
+      nx >= 0 &&
+      ny >= 0 &&
+      nx < gridSize &&
+      ny < gridSize &&
+      map[ny][nx].type === 'path' &&
+      !visited.has(`${nx},${ny}`)
+    );
   });
   if (dirs.length === 0) return; // stuck
   const dir = randChoice(dirs);
@@ -339,8 +354,11 @@ window.addEventListener('DOMContentLoaded', () => {
     createMap();
     spawnHero();
     for (let i = 0; i < 5; i++) {
-      const x = Math.floor(Math.random() * gridSize);
-      const y = Math.floor(Math.random() * gridSize);
+      let x, y;
+      do {
+        x = Math.floor(Math.random() * gridSize);
+        y = Math.floor(Math.random() * gridSize);
+      } while (map[y][x].type !== 'path');
       spawnMonster(x, y);
     }
   }
@@ -350,3 +368,10 @@ window.addEventListener('DOMContentLoaded', () => {
   });
   render();
 });
+
+window.dig = function (x, y) {
+  if (map[y] && map[y][x]) {
+    map[y][x].type = 'path';
+    render();
+  }
+};

--- a/scripts/hero_ai.js
+++ b/scripts/hero_ai.js
@@ -19,6 +19,7 @@ export class HeroAI {
         ny >= 0 &&
         nx < map.width &&
         ny < map.height &&
+        map.tiles[ny][nx].type === 'path' &&
         !this.visited.has(`${nx},${ny}`)
       );
     });

--- a/scripts/layered_map_renderer.js
+++ b/scripts/layered_map_renderer.js
@@ -66,7 +66,8 @@ export class LayeredMapRenderer {
       grass: '#77aa77',
       soil: '#aa8855',
       rock: '#888888',
-      building: '#5555aa'
+      building: '#5555aa',
+      path: '#dcb35c'
     };
     this.ctx.fillStyle = colors[type] || '#000000';
     this.ctx.fillRect(

--- a/scripts/map_renderer.js
+++ b/scripts/map_renderer.js
@@ -12,9 +12,13 @@ export class MapRenderer {
     for (let y = 0; y < this.map.height; y++) {
       for (let x = 0; x < this.map.width; x++) {
         const tile = this.map.tiles[y][x];
-        const mana = tile.mana;
-        const nutrients = tile.nutrients;
-        this.ctx.fillStyle = `rgb(${mana * 30}, ${nutrients * 30}, 100)`;
+        if (tile.type === 'path') {
+          this.ctx.fillStyle = '#dcb35c';
+        } else {
+          const mana = tile.mana;
+          const nutrients = tile.nutrients;
+          this.ctx.fillStyle = `rgb(${mana * 30}, ${nutrients * 30}, 100)`;
+        }
         this.ctx.fillRect(
           x * this.cellSize,
           y * this.cellSize,

--- a/scripts/monster_ai.js
+++ b/scripts/monster_ai.js
@@ -15,9 +15,14 @@ function getValidDirs(x, y, map) {
     [0, 1],
     [0, -1]
   ];
-  return dirs.filter(d =>
-    inBounds(x + d[0], y + d[1], map[0].length, map.length)
-  );
+  return dirs.filter(d => {
+    const nx = x + d[0];
+    const ny = y + d[1];
+    return (
+      inBounds(nx, ny, map[0].length, map.length) &&
+      map[ny][nx].type === 'path'
+    );
+  });
 }
 
 function moveToward(x, y, tx, ty) {


### PR DESCRIPTION
## Summary
- add path tiles to layered_map.json
- render path tiles in map renderer
- allow digging to create new path tiles
- restrict hero and monster movement to paths only
- ensure demo scene generates an initial path

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68538750268c832eaa914d27755bc830