### PR TITLE
Add utility helpers and refactor usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,18 @@
 | `data/monsters.json` | IDと進化情報を簡易登録 | 追加種族や進化分岐の拡充 |
 | `data/monsters_detailed.json` | 詳細データを一部記載 | ゲームロジックとの連携 |
 | `lib/resourceManager.js` | マップ生成・Wave管理のみ | 養分・魔分循環処理の実装 |
-| `lib/utils.js` | 単体デモ用の掘削処理 | 本編スクリプトへの統合 |
+| `lib/utils.js` | 乱数や補助関数を提供 | ドキュメント整備 |
 | `scripts/game.js` | 基本的なターン制は動作 | 処理の整理とテスト追加 |
 | `scripts/hero_ai.js` | 右手法ベースで動作 | トラップ対応や記憶強化 |
 | `scripts/monster_ai.js` | 種族別の挙動を実装 | 行動分岐やAI強化 |
 | `scripts/monster_canvas.js` | 成長デモを確認可能 | バランス調整・UI改良 |
 | `scenes/*.html` | 各画面の最低限表示のみ | 演出・デザインの作り込み |
 | `assets/` | `.gitkeep`のみで実データ未登録 | 実際の画像アセットを準備 |
+
+### 共通ユーティリティ
+- `randomInt(min, max)` : 指定範囲の整数を返す
+- `clamp(value, min, max)` : 値を範囲内に収める
+- `randChoice(array)` : 配列から要素をランダム選択
 
 ### 未着手・中途半端な項目
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,53 +1,25 @@
-// 掘削処理：クリック or タップでマスを掘る
+// Common utility helpers used across the game logic
+// randomInt(min, max)  -> returns integer in [min, max]
+// clamp(value, min, max) -> clamps a numeric value inside the given range
+// randChoice(array) -> returns a random element from a non-empty array
 
-function generateInitialMap(width, height) {
-  const tiles = [];
-  for (let y = 0; y < height; y++) {
-    const row = [];
-    for (let x = 0; x < width; x++) {
-      row.push({ dug: false, mana: Math.random(), nutrients: Math.random() });
-    }
-    tiles.push(row);
+(function(global){
+  function randomInt(min, max){
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min + 1)) + min;
   }
-  return { width, height, tiles };
-}
 
-// 初期マップ生成
-const mapData = generateInitialMap(20, 20);
-const tileSize = 20; // 1マスのピクセルサイズ（仮）
-
-const canvas = document.getElementById('gameCanvas');
-const ctx = canvas.getContext('2d');
-canvas.width = mapData.width * tileSize;
-canvas.height = mapData.height * tileSize;
-
-// マップ描画（未掘削はグレー、掘削済みは紫〜緑）
-function renderMap() {
-  for (let y = 0; y < mapData.height; y++) {
-    for (let x = 0; x < mapData.width; x++) {
-      const tile = mapData.tiles[y][x];
-      if (!tile.dug) {
-        ctx.fillStyle = '#444';
-      } else {
-        const mana = tile.mana;
-        const nutrients = tile.nutrients;
-        ctx.fillStyle = `rgb(${mana * 50}, ${nutrients * 60}, 100)`;
-      }
-      ctx.fillRect(x * tileSize, y * tileSize, tileSize, tileSize);
-    }
+  function clamp(value, min, max){
+    return Math.max(min, Math.min(max, value));
   }
-}
 
-// 掘削処理
-canvas.addEventListener('click', (e) => {
-  const rect = canvas.getBoundingClientRect();
-  const x = Math.floor((e.clientX - rect.left) / tileSize);
-  const y = Math.floor((e.clientY - rect.top) / tileSize);
-  const tile = mapData.tiles[y][x];
-  if (!tile.dug) {
-    tile.dug = true;
-    renderMap();
+  function randChoice(array){
+    if(!array || array.length === 0) return undefined;
+    return array[randomInt(0, array.length - 1)];
   }
-});
 
-renderMap();
+  global.randomInt = randomInt;
+  global.clamp = clamp;
+  global.randChoice = randChoice;
+})(this);

--- a/scenes/game.html
+++ b/scenes/game.html
@@ -16,6 +16,7 @@
     </div>
     <canvas id="gameCanvas"></canvas>
   </main>
+  <script src="../lib/utils.js"></script>
   <script src="../scripts/save_manager.js"></script>
   <script src="../scripts/monster_ai.js"></script>
   <script src="../scripts/game.js"></script>

--- a/scenes/hero_invade.html
+++ b/scenes/hero_invade.html
@@ -19,6 +19,7 @@
     <div id="banter"></div>
     <canvas id="mapCanvas"></canvas>
   </main>
+  <script src="../lib/utils.js"></script>
   <script type="module">
     import { generateMap } from '../lib/resourceManager.js';
     import { HeroAI } from '../scripts/hero_ai.js';

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -37,9 +37,7 @@ function loadState() {
   return true;
 }
 
-function randChoice(arr) {
-  return arr[Math.floor(Math.random() * arr.length)];
-}
+
 
 function createMap() {
   map = [];
@@ -356,8 +354,8 @@ window.addEventListener('DOMContentLoaded', () => {
     for (let i = 0; i < 5; i++) {
       let x, y;
       do {
-        x = Math.floor(Math.random() * gridSize);
-        y = Math.floor(Math.random() * gridSize);
+        x = randomInt(0, gridSize-1);
+        y = randomInt(0, gridSize-1);
       } while (map[y][x].type !== 'path');
       spawnMonster(x, y);
     }

--- a/scripts/hero_ai.js
+++ b/scripts/hero_ai.js
@@ -25,7 +25,7 @@ export class HeroAI {
     });
 
     if (dirs.length === 0) return null;
-    const dir = dirs[Math.floor(Math.random() * dirs.length)];
+    const dir = randChoice(dirs);
     this.x += dir[0];
     this.y += dir[1];
     this.visited.add(`${this.x},${this.y}`);

--- a/scripts/monster_ai.js
+++ b/scripts/monster_ai.js
@@ -4,10 +4,6 @@ function inBounds(x, y, width, height) {
   return x >= 0 && y >= 0 && x < width && y < height;
 }
 
-function randChoice(arr) {
-  return arr[Math.floor(Math.random() * arr.length)];
-}
-
 function getValidDirs(x, y, map) {
   const dirs = [
     [1, 0],


### PR DESCRIPTION
## Summary
- implement randomInt, clamp, and randChoice in `lib/utils.js`
- load utils on game and hero invasion pages
- use helpers in hero AI, monster AI and game logic
- document utilities in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853ec3d5498832ead3822d699a2c2be