### PR TITLE
Add simple monster placement UI

### DIFF
--- a/scenes/monster_canvas.html
+++ b/scenes/monster_canvas.html
@@ -6,10 +6,16 @@
   <link rel="stylesheet" href="../styles/styles.css" />
 </head>
 <body>
-  <header>
+  <header style="position: relative;">
     <h1>モンスターラボ</h1>
+    <span id="costLabel" style="position:absolute; top:10px; right:10px;">召喚コスト：100</span>
   </header>
   <main>
+    <div class="control-panel">
+      <button class="monster-select" data-monster="slime">スライム</button>
+      <button class="monster-select" data-monster="bat">こうもり</button>
+      <button id="startWave">wave開始</button>
+    </div>
     <canvas id="monsterCanvas"></canvas>
     <pre id="log" style="position: absolute; top: 5px; right: 5px;
       background: rgba(255,255,255,0.8); padding: 4px;"></pre>

--- a/scripts/monster_canvas.js
+++ b/scripts/monster_canvas.js
@@ -6,6 +6,9 @@ const tileSize = 20; // same as renderMap
 let canvas, ctx;
 let resourceMap, resourceManager;
 let monsters = [];
+let summonPoints = 100;
+let selectedMonster = null;
+const SUMMON_COST = 20;
 
 function init() {
   canvas = document.getElementById('monsterCanvas');
@@ -22,6 +25,25 @@ function init() {
   );
 
   canvas.addEventListener('click', onClick);
+
+  document.querySelectorAll('.monster-select').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document
+        .querySelectorAll('.monster-select')
+        .forEach(b => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      selectedMonster = btn.dataset.monster;
+    });
+  });
+
+  const startBtn = document.getElementById('startWave');
+  if (startBtn) {
+    startBtn.addEventListener('click', () => {
+      console.log('Wave started!');
+    });
+  }
+
+  updateCost();
 }
 
 function onClick(e) {
@@ -31,8 +53,12 @@ function onClick(e) {
 
   if (x < 0 || y < 0 || x >= resourceMap.width || y >= resourceMap.height) return;
   if (monsters[y][x]) return;
+  if (!selectedMonster) return;
+  if (summonPoints < SUMMON_COST) return;
 
   monsters[y][x] = true;
+  summonPoints -= SUMMON_COST;
+  updateCost();
   const result = resourceManager.absorbResources(x, y);
   draw();
   log(`(${x},${y}) -> nutrients:${result.nutrients} mana:${result.mana}`);
@@ -48,6 +74,11 @@ function draw() {
       }
     }
   }
+}
+
+function updateCost() {
+  const el = document.getElementById('costLabel');
+  if (el) el.textContent = `召喚コスト：${summonPoints}`;
 }
 
 function log(msg) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -23,6 +23,14 @@ button {
   padding: 4px 12px;
 }
 
+.monster-select.selected {
+  background-color: #ffd85e;
+}
+
+#costLabel {
+  font-weight: bold;
+}
+
 canvas {
   border: 1px solid #444;
   display: block;


### PR DESCRIPTION
## Summary
- add summoning cost display and buttons to `monster_canvas.html`
- style selected monster and cost label in CSS
- implement monster selection, cost handling and wave start logging in JS

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854d795fa28832e9392a71dfef7cf00