### PR TITLE
Add phase control to TurnManager

### DIFF
--- a/scenes/hero_invade.html
+++ b/scenes/hero_invade.html
@@ -75,27 +75,36 @@
         `Stage ${tm.currentStage} Wave ${tm.currentWave} (${team}) - Phase: ${tm.phase}`;
     }
 
-    async function nextTurn() {
-      if (tm.isFinished()) return;
+    tm.on('placement', async () => {
+      // リソース吸収などの処理をここで行う
+      await tm.nextPhase();
+    });
 
-      if (tm.phase === 'prepare') {
-        await startWave();
-      } else {
-        heroes.forEach(h => h.getNextMove(map));
-        if (banter.length > 0) {
-          document.getElementById('banter').textContent =
-            banter[banterIndex % banter.length];
-          banterIndex += 1;
-        }
+    tm.on('waveStart', startWave);
+
+    tm.on('heroTurn', () => {
+      heroes.forEach(h => h.getNextMove(map));
+      if (banter.length > 0) {
+        document.getElementById('banter').textContent =
+          banter[banterIndex % banter.length];
+        banterIndex += 1;
       }
+    });
 
-      tm.nextPhase();
+    tm.on('transition', () => {
+      heroes = [];
+      banter = [];
+      banterIndex = 0;
+    });
+
+    document.getElementById('nextTurn').addEventListener('click', async () => {
+      await tm.nextPhase();
       renderer.render(heroes);
       updateStatus();
-    }
+    });
 
-    document.getElementById('nextTurn').addEventListener('click', nextTurn);
     renderer.render();
+    tm.start();
     updateStatus();
 
     window.dig = (x, y) => {

--- a/scripts/turn_manager.js
+++ b/scripts/turn_manager.js
@@ -4,21 +4,57 @@ export class TurnManager {
     this.wavesPerStage = wavesPerStage;
     this.currentStage = 1;
     this.currentWave = 1; // wave number within stage
-    this.phase = 'prepare';
+
+    this.phaseOrder = [
+      'prepare',
+      'placement',
+      'waveStart',
+      'heroTurn',
+      'cleanup',
+      'waveEnd',
+      'transition'
+    ];
+    this.phaseIndex = 0;
+    this.phase = this.phaseOrder[this.phaseIndex];
+
+    this.handlers = {};
   }
 
-  nextPhase() {
-    if (this.phase === 'prepare') {
-      this.phase = 'wave';
-    } else {
-      this.phase = 'prepare';
+  on(phase, handler) {
+    if (!this.handlers[phase]) this.handlers[phase] = [];
+    this.handlers[phase].push(handler);
+  }
+
+  async trigger() {
+    const list = this.handlers[this.phase] || [];
+    for (const h of list) {
+      await h(this);
+    }
+  }
+
+  async start() {
+    this.phaseIndex = 0;
+    this.phase = this.phaseOrder[this.phaseIndex];
+    await this.trigger();
+  }
+
+  async nextPhase() {
+    if (this.isFinished()) return;
+
+    this.phaseIndex += 1;
+    if (this.phaseIndex >= this.phaseOrder.length) {
+      this.phaseIndex = 0;
       if (this.currentWave >= this.wavesPerStage) {
         this.currentWave = 1;
         this.currentStage += 1;
       } else {
         this.currentWave += 1;
       }
+      if (this.isFinished()) return;
     }
+
+    this.phase = this.phaseOrder[this.phaseIndex];
+    await this.trigger();
   }
 
   isFinished() {
@@ -26,7 +62,11 @@ export class TurnManager {
   }
 
   getWaveIndex() {
-    return (this.currentStage - 1) * this.wavesPerStage + (this.currentWave - 1);
+    return (
+      (this.currentStage - 1) * this.wavesPerStage +
+      (this.currentWave - 1)
+    );
   }
 }
+
 


### PR DESCRIPTION
## Summary
- expand `TurnManager` to support multiple phases and event hooks
- drive hero invasion flow with new phase events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855ec1829dc832e8de0a3f23d57041f