### PR TITLE
Apply Press Start 2P font across UI

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
 body {
   margin: 0;
   font-family: sans-serif;
@@ -21,6 +23,8 @@ main {
 button {
   margin-right: 6px;
   padding: 4px 12px;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 14px;
 }
 
 .monster-select.selected {
@@ -29,6 +33,8 @@ button {
 
 #costLabel {
   font-weight: bold;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 14px;
 }
 
 canvas {
@@ -39,6 +45,14 @@ canvas {
 
 #status {
   margin-top: 5px;
-  font-size: 14px;
   color: #333;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 14px;
+}
+
+#concept,
+#quote,
+#banter {
+  font-family: 'Press Start 2P', cursive;
+  font-size: 12px;
 }


### PR DESCRIPTION
## Summary
- import "Press Start 2P" from Google Fonts
- use the pixel font for buttons, score/status text, and message windows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855ee58f25c832e8be680ca6aa6038f