### PR TITLE
Refactor turn flow with modular AI and manager

### DIFF
--- a/scripts/hero_ai.js
+++ b/scripts/hero_ai.js
@@ -5,6 +5,12 @@ export class HeroAI {
     this.visited = new Set([`${this.x},${this.y}`]);
   }
 
+  reset(x = 0, y = 0) {
+    this.x = x;
+    this.y = y;
+    this.visited = new Set([`${x},${y}`]);
+  }
+
   getNextMove(map) {
     const dirs = [
       [1, 0],
@@ -31,5 +37,9 @@ export class HeroAI {
     this.visited.add(`${this.x},${this.y}`);
     return { x: this.x, y: this.y };
   }
+}
+
+if (typeof window !== 'undefined') {
+  window.HeroAI = HeroAI;
 }
 

--- a/scripts/turn_manager.js
+++ b/scripts/turn_manager.js
@@ -69,4 +69,8 @@ export class TurnManager {
   }
 }
 
+if (typeof window !== 'undefined') {
+  window.TurnManager = TurnManager;
+}
+
 


### PR DESCRIPTION
## Summary
- integrate TurnManager phase control into `game.js`
- move hero movement to `HeroAI` and add a reset helper
- expose `HeroAI` and `TurnManager` as globals for non-module use
- update game logic to register phase handlers and remove old `heroMove`

## Testing
- `node --check scripts/hero_ai.js`
- `node --check scripts/turn_manager.js`
- `node --check scripts/game.js`


------
https://chatgpt.com/codex/tasks/task_e_685a118acf44832eaa83d431356d83a6