### PR TITLE
Add speech bubble overlay to show attack lines

### DIFF
--- a/scenes/game.html
+++ b/scenes/game.html
@@ -16,10 +16,12 @@
       <span id="status"></span>
     </div>
     <canvas id="gameCanvas"></canvas>
+    <div id="speechLayer"></div>
   </main>
   <script src="../lib/utils.js"></script>
   <script src="../scripts/save_manager.js"></script>
   <script src="../scripts/monster_ai.js"></script>
+  <script src="../scripts/speechLayer.js"></script>
   <script src="../scripts/game.js"></script>
 </body>
 </html>

--- a/scripts/game.js
+++ b/scripts/game.js
@@ -203,6 +203,13 @@ function resizeCanvas() {
   );
   canvas.style.width = `${BASE_WIDTH * scale}px`;
   canvas.style.height = `${BASE_HEIGHT * scale}px`;
+  const layer = document.getElementById('speechLayer');
+  if (layer) {
+    layer.style.width = canvas.style.width;
+    layer.style.height = canvas.style.height;
+    layer.style.left = canvas.offsetLeft + 'px';
+    layer.style.top = canvas.offsetTop + 'px';
+  }
 }
 
 function saveState() {
@@ -387,6 +394,9 @@ function autoBattle(monster, mx, my, heroFirst) {
           0
         )})`
       );
+      if (typeof showSpeechBubble === 'function') {
+        showSpeechBubble(hero.x, hero.y, atkName);
+      }
     } else {
       const heroStats = hero.getEffectiveStats();
       const heroDef =
@@ -403,6 +413,9 @@ function autoBattle(monster, mx, my, heroFirst) {
           0
         )})`
       );
+      if (typeof showSpeechBubble === 'function') {
+        showSpeechBubble(mx, my, atkName);
+      }
     }
     heroTurn = !heroTurn;
   }

--- a/scripts/speechLayer.js
+++ b/scripts/speechLayer.js
@@ -1,0 +1,17 @@
+(function () {
+  const layer = document.getElementById('speechLayer');
+  window.showSpeechBubble = function (x, y, text) {
+    if (!layer) return;
+    const bubble = document.createElement('div');
+    bubble.className = 'speech-bubble';
+    bubble.textContent = text;
+    const px = offsetX + x * cellSize * gameScale + (cellSize * gameScale) / 2;
+    const py = offsetY + y * cellSize * gameScale;
+    bubble.style.left = px + 'px';
+    bubble.style.top = py + 'px';
+    layer.appendChild(bubble);
+    setTimeout(() => {
+      if (bubble.parentNode) bubble.parentNode.removeChild(bubble);
+    }, 1500);
+  };
+})();

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -14,6 +14,7 @@ header {
 
 main {
   padding: 20px;
+  position: relative;
 }
 
 .control-panel {
@@ -55,4 +56,25 @@ canvas {
 #banter {
   font-family: 'Press Start 2P', cursive;
   font-size: 12px;
+}
+
+#speechLayer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.speech-bubble {
+  position: absolute;
+  background: #ffffff;
+  border: 2px solid #000000;
+  border-radius: 6px;
+  padding: 2px 6px;
+  font-family: 'Press Start 2P', cursive;
+  font-size: 12px;
+  white-space: nowrap;
+  transform: translate(-50%, -100%);
 }


### PR DESCRIPTION
## Summary
- overlay speech layer div on the game canvas
- display short speech bubbles using `showSpeechBubble`
- style bubbles with simple white background and black border
- adjust canvas resize to keep the speech layer aligned
- trigger bubbles when heroes and monsters attack

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_685a8bf72360832e8ca9ad072cef1511