### PR TITLE
Add simple monster evolution demo

### DIFF
--- a/data/simple_monsters.json
+++ b/data/simple_monsters.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "slime",
+    "name": "スライム",
+    "color": "#00cc88",
+    "growthTurns": 3,
+    "evolvedTo": "slime_lord"
+  },
+  {
+    "id": "slime_lord",
+    "name": "スライムロード",
+    "color": "#004488"
+  },
+  {
+    "id": "bat",
+    "name": "コウモリ",
+    "color": "#cc00cc",
+    "growthTurns": 3,
+    "evolvedTo": "bat_king"
+  },
+  {
+    "id": "bat_king",
+    "name": "バットキング",
+    "color": "#660066"
+  }
+]

--- a/scenes/index.html
+++ b/scenes/index.html
@@ -13,6 +13,7 @@
     <ul>
       <li><a href="title.html">🎬 タイトル画面</a></li>
       <li><a href="monster_canvas.html">🧪 モンスターラボを開く</a></li>
+      <li><a href="simple_evolution.html">🧬 シンプル進化デモ</a></li>
       <li><a href="game.html">🎮 勇者ゲームをプレイ</a></li>
       <li><a href="layered_map.html">🗺️ レイヤーマップ表示</a></li>
     </ul>

--- a/scenes/simple_evolution.html
+++ b/scenes/simple_evolution.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>シンプル進化シミュレーション</title>
+  <link rel="stylesheet" href="../styles/styles.css" />
+  <style>
+    #monsterCanvas { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>進化シミュレーション</h1>
+  </header>
+  <main>
+    <div class="control-panel">
+      <select id="monsterSelect"></select>
+      <button id="nextTurn">次のターン</button>
+      <button id="reset">リセット</button>
+      <span id="status"></span>
+    </div>
+    <canvas id="monsterCanvas"></canvas>
+  </main>
+  <script src="../scripts/simple_evolution_sim.js"></script>
+</body>
+</html>

--- a/scripts/simple_evolution_sim.js
+++ b/scripts/simple_evolution_sim.js
@@ -1,0 +1,97 @@
+const canvas = document.getElementById('monsterCanvas');
+const ctx = canvas.getContext('2d');
+canvas.width = 400;
+canvas.height = 400;
+
+const gridSize = 10;
+const cellSize = canvas.width / gridSize;
+
+let monsters = Array.from({ length: gridSize }, () => Array(gridSize).fill(null));
+let monsterData = {};
+let lastClicked = null;
+
+// モンスター定義読み込み（外部JSON）
+fetch('../data/simple_monsters.json')
+  .then(response => response.json())
+  .then(data => {
+    data.forEach(m => {
+      monsterData[m.id] = m;
+      const option = document.createElement('option');
+      option.value = m.id;
+      option.textContent = m.name;
+      document.getElementById('monsterSelect').appendChild(option);
+    });
+  });
+
+// 配置処理：Canvasクリックで魔物設置
+canvas.addEventListener('click', e => {
+  const rect = canvas.getBoundingClientRect();
+  const x = Math.floor((e.clientX - rect.left) / cellSize);
+  const y = Math.floor((e.clientY - rect.top) / cellSize);
+  const selectedId = document.getElementById('monsterSelect').value;
+  if (monsterData[selectedId]) {
+    monsters[y][x] = { id: selectedId, age: 0, evolved: false };
+    render();
+    updateStatus(x, y);
+    lastClicked = { x, y };
+  }
+});
+
+// ボタン処理
+document.getElementById('nextTurn').addEventListener('click', advanceTurn);
+document.getElementById('reset').addEventListener('click', () => {
+  monsters = Array.from({ length: gridSize }, () => Array(gridSize).fill(null));
+  render();
+  document.getElementById('status').textContent = '';
+});
+
+// ターン進行処理（成長＆進化）
+function advanceTurn() {
+  for (let y = 0; y < gridSize; y++) {
+    for (let x = 0; x < gridSize; x++) {
+      const m = monsters[y][x];
+      if (!m) continue;
+      const data = monsterData[m.id];
+      m.age += 1;
+      if (!m.evolved && m.age >= (data.growthTurns || Infinity) && data.evolvedTo) {
+        m.id = data.evolvedTo;
+        m.evolved = true;
+      }
+    }
+  }
+  render();
+  if (lastClicked) {
+    const { x, y } = lastClicked;
+    if (monsters[y][x]) {
+      updateStatus(x, y);
+    } else {
+      document.getElementById('status').textContent = '';
+    }
+  }
+}
+
+// ステータス欄更新
+function updateStatus(x, y) {
+  const m = monsters[y][x];
+  if (!m) {
+    document.getElementById('status').textContent = '';
+    return;
+  }
+  const data = monsterData[m.id];
+  document.getElementById('status').textContent = `${data.name}（Age: ${m.age}）`;
+}
+
+// 描画処理
+function render() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  for (let y = 0; y < gridSize; y++) {
+    for (let x = 0; x < gridSize; x++) {
+      const m = monsters[y][x];
+      if (m) {
+        const data = monsterData[m.id];
+        ctx.fillStyle = data.color || '#cccccc';
+        ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple JSON file with a few monsters
- add simple_evolution.html with missing controls
- implement simple_evolution_sim.js that loads monsters and handles evolution
- link the page from index.html

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685bde772e78832e8a05fbedc3622407