### PR TITLE
Enhance hero & monster interaction

### DIFF
--- a/scenes/hero_invade.html
+++ b/scenes/hero_invade.html
@@ -23,7 +23,7 @@
   <script type="module">
     import { generateMap } from '../lib/resourceManager.js';
     import { HeroAI } from '../scripts/hero_ai.js';
-    import { MapRenderer } from '../scripts/map_renderer.js';
+    import { MapRenderer, placeHeroesOnMap } from '../scripts/map_renderer.js';
     import { TurnManager } from '../scripts/turn_manager.js';
     import config from '../data/game_config.json' assert { type: 'json' };
     import mapInfo from '../data/map.json' assert { type: 'json' };
@@ -99,10 +99,12 @@
 
     document.getElementById('nextTurn').addEventListener('click', async () => {
       await tm.nextPhase();
-      renderer.render(heroes);
+      placeHeroesOnMap(heroes, map);
+      renderer.render();
       updateStatus();
     });
 
+    placeHeroesOnMap(heroes, map);
     renderer.render();
     tm.start();
     updateStatus();
@@ -110,7 +112,8 @@
     window.dig = (x, y) => {
       if (map.tiles[y] && map.tiles[y][x]) {
         map.tiles[y][x].type = 'path';
-        renderer.render(heroes);
+        placeHeroesOnMap(heroes, map);
+        renderer.render();
       }
     };
   </script>

--- a/scripts/map_renderer.js
+++ b/scripts/map_renderer.js
@@ -8,11 +8,15 @@ export class MapRenderer {
     canvas.height = map.height * this.cellSize;
   }
 
-  render(heroes = []) {
+  render() {
     for (let y = 0; y < this.map.height; y++) {
       for (let x = 0; x < this.map.width; x++) {
         const tile = this.map.tiles[y][x];
-        if (tile.type === 'path') {
+        if (tile.monster) {
+          this.ctx.fillStyle = '#33cc99';
+        } else if (tile.hero) {
+          this.ctx.fillStyle = '#3366cc';
+        } else if (tile.type === 'path') {
           this.ctx.fillStyle = '#dcb35c';
         } else {
           const mana = tile.mana;
@@ -27,16 +31,21 @@ export class MapRenderer {
         );
       }
     }
+  }
+}
 
-    this.ctx.fillStyle = 'blue';
-    heroes.forEach(h => {
-      this.ctx.fillRect(
-        h.x * this.cellSize,
-        h.y * this.cellSize,
-        this.cellSize,
-        this.cellSize
-      );
-    });
+export function placeHeroesOnMap(heroes, map) {
+  const tiles = map.tiles || map;
+  for (const row of tiles) {
+    for (const cell of row) {
+      delete cell.hero;
+    }
+  }
+  if (!heroes) return;
+  for (const h of heroes) {
+    if (h && h.x >= 0 && h.y >= 0 && h.y < tiles.length && h.x < tiles[0].length) {
+      tiles[h.y][h.x].hero = h;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- support multiple heroes and nearest-hero targeting for monsters
- render heroes directly from map tiles
- allow hero placement to be written into map data
- update hero invasion sample to use new utilities

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bed4eb208832e93d2f6160d82b509